### PR TITLE
Feat: Logics for Cache-map with Dirty_Bit

### DIFF
--- a/include/lru.h
+++ b/include/lru.h
@@ -22,7 +22,7 @@ extern "C" {
 /**
  * @brief deallocate the value for eviction function type. 0 means successfully evicted
  */
-typedef int (*lru_dealloc_fn)(const uint64_t, uintptr_t);
+typedef int (*lru_dealloc_fn)(const uint64_t, uintptr_t, int*);
 
 /**
  * @brief doubly-linked list data structure
@@ -32,6 +32,7 @@ struct lru_node {
 	uintptr_t value;
 	struct lru_node *next;
 	struct lru_node *prev;
+	int Dirty_Bit;
 };
 
 /**
@@ -43,6 +44,8 @@ struct lru_cache {
 	struct lru_node *head;
 	lru_dealloc_fn deallocate;
 	struct lru_node nil; /**< don't access this directly */
+
+	int Dirty_Count;
 };
 
 struct lru_cache *lru_init(const size_t capacity, lru_dealloc_fn deallocate);
@@ -50,6 +53,8 @@ int lru_put(struct lru_cache *cache, const uint64_t key, uintptr_t value);
 uintptr_t lru_get(struct lru_cache *cache, const uint64_t key);
 int lru_free(struct lru_cache *cache);
 
+uintptr_t lru_get_n_get_node(struct lru_cache *cache, const uint64_t key, struct lru_node **ret_node);//This
+int lru_put_n_get_node(struct lru_cache *, const uint64_t , uintptr_t , struct lru_node **);//This
 /**
  * @brief get evict size of the LRU cache
  *

--- a/include/page.h
+++ b/include/page.h
@@ -89,6 +89,7 @@ int page_ftl_update_map(struct page_ftl *, size_t sector, uint32_t ppn);
 
 /* page-core.c */
 int page_ftl_segment_data_init(struct page_ftl *, struct page_ftl_segment *);
+void page_ftl_Dirty_set(struct page_ftl *pgftl, int *Dirty_Bit, const int WRITE_FLAG);
 
 /* page-gc.c */
 ssize_t page_ftl_do_gc(struct page_ftl *);

--- a/include/page.h
+++ b/include/page.h
@@ -20,7 +20,7 @@
 #include "flash.h"
 #include "device.h"
 
-// #define PAGE_FTL_USE_CACHE
+#define PAGE_FTL_USE_CACHE
 #define PAGE_FTL_CACHE_SIZE ((1 << 10))
 #define PAGE_FTL_GC_RATIO                                                      \
 	((double)10 /                                                          \

--- a/run
+++ b/run
@@ -1,0 +1,1 @@
+./benchmark.out -m pgftl -d ramdisk -t write -j 4 -b 1048576 -n 100

--- a/single_view_vlog
+++ b/single_view_vlog
@@ -1,0 +1,3 @@
+./compile_cmd;
+clear;
+./benchmark.out -m pgftl -d ramdisk -t write -j 1 -b 1048576 -n 100 > ./log

--- a/start
+++ b/start
@@ -1,0 +1,4 @@
+make clean;
+clear;
+make -j$(nproc);
+./benchmark.out -m pgftl -d ramdisk -t write -j 4 -b 1048576 -n 100

--- a/view_log
+++ b/view_log
@@ -1,0 +1,3 @@
+./compile_cmd;
+clear;
+./benchmark.out -m pgftl -d ramdisk -t write -j 4 -b 1048576 -n 100 > ./log


### PR DESCRIPTION
page-write - Dirty bit
page-read - Dirty bit 
```
free(): corrupted unsorted chunks
Aborted
```

from **_page-write.c : 158_**
```
free(request->data);
```
